### PR TITLE
allow setting specific version of the application

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
     "CAPABILITY_IAM",
     "CAPABILITY_RESOURCE_POLICY",
   ]
+  semantic_version = var.rotation_application_version
   parameters = {
     functionName = local.name
     endpoint     = "https://secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,12 @@ variable "rotation_lambda_vpc_id" {
   default     = null
 }
 
+variable "rotation_application_version" {
+  description = "The semantic version that the lambda will use"
+  type        = string
+  default     = "1.1.447"
+}
+
 variable "db_security_group_id" {
   description = "The security group ID for the database. Required for secret rotation."
   type        = string


### PR DESCRIPTION
In order to update to the latest version of the rotation lambda, we need to be able to set a target version. Setting the default to the current latest.